### PR TITLE
Add environment variable MYSQL_ROOT_PASSWORD_FILE that allows root password to be set from file contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ docker create \
   -e PUID=1000 \
   -e PGID=1000 \
   -e MYSQL_ROOT_PASSWORD=<DATABASE PASSWORD> \
+  -e MYSQL_ROOT_PASSWORD_FILE=<DATABASE PASSWORD FILE> \
   -e TZ=Europe/London \
   -e MYSQL_DATABASE=<USER DB NAME> `#optional` \
   -e MYSQL_USER=<MYSQL USER> `#optional` \
@@ -88,7 +89,8 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - MYSQL_ROOT_PASSWORD=<DATABASE PASSWORD>
+      - MYSQL_ROOT_PASSWORD=<DATABASE PASSWORD> # Takes precedence over the file
+      - MYSQL_ROOT_PASSWORD_FILE=<DATABASE PASSWORD FILE>
       - TZ=Europe/London
       - MYSQL_DATABASE=<USER DB NAME> #optional
       - MYSQL_USER=<MYSQL USER> #optional
@@ -109,7 +111,8 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-p 3306` | Mariadb listens on this port. |
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
-| `-e MYSQL_ROOT_PASSWORD=<DATABASE PASSWORD>` | Set this to root password for installation (minimum 4 characters). |
+| `-e MYSQL_ROOT_PASSWORD=<DATABASE PASSWORD>` | Set this to root password for installation (minimum 4 characters). This variable takes precedence over a password file. |
+| `-e MYSQL_ROOT_PASSWORD_FILE=<DATABASE PASSWORD FILE>` | Set this to a file containing the desired root password (useful for docker secrets). Same password rules apply. |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
 | `-e MYSQL_DATABASE=<USER DB NAME>` | Specify the name of a database to be created on image startup. |
 | `-e MYSQL_USER=<MYSQL USER>` | This user will have superuser access to the database specified by MYSQL_DATABASE. |

--- a/root/etc/cont-init.d/40-initialise-db
+++ b/root/etc/cont-init.d/40-initialise-db
@@ -34,7 +34,7 @@ EOFPASS
 
 # test for empty password variable, if it's set to 0 or less than 4 characters
 if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
-	if [ -r "$MYSQL_ROOT_PASSWORD_FILE" ]; then
+	if [ -f "$MYSQL_ROOT_PASSWORD_FILE" -a -r "$MYSQL_ROOT_PASSWORD_FILE" ]; then
 		MYSQL_ROOT_PASSWORD=$(< "$MYSQL_ROOT_PASSWORD_FILE")
 	else
 		TEST_LEN="0"

--- a/root/etc/cont-init.d/40-initialise-db
+++ b/root/etc/cont-init.d/40-initialise-db
@@ -34,9 +34,13 @@ EOFPASS
 
 # test for empty password variable, if it's set to 0 or less than 4 characters
 if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
-TEST_LEN="0"
+	if [ -r "$MYSQL_ROOT_PASSWORD_FILE" ]; then
+		MYSQL_ROOT_PASSWORD=$(< "$MYSQL_ROOT_PASSWORD_FILE")
+	else
+		TEST_LEN="0"
+	fi
 else
-TEST_LEN=${#MYSQL_ROOT_PASSWORD}
+	TEST_LEN=${#MYSQL_ROOT_PASSWORD}
 fi
 if [ "$TEST_LEN" -lt "4" ]; then
 MYSQL_PASS="CREATE USER 'root'@'%' IDENTIFIED BY '' ;"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
Addresses #35 

Added an environment variable that's used in the container init file to load the root password from a file. It's only loaded if the normal password env var isn't set. Length check is still applied.

This is useful if you don't want the root password present in your docker-compose, or if you're using docker secrets.

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

