### PR TITLE
#38 #5 #26  bump maria to 10.4, ability to ingest sql files, ability to set password via file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG MARIADB_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="thelamer"
 
 # environment variables
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -20,9 +20,9 @@ RUN \
  echo "add mariadb repository ****" && \
  echo "(redundant on armhf platform, but added for consistent dockerfile on all platforms) ****" && \
  apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8 && \
- echo "deb http://mirror.sax.uk.as61049.net/mariadb/repo/10.3/ubuntu bionic main" >> \
+ echo "deb http://mirror.sax.uk.as61049.net/mariadb/repo/10.4/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/mariadb.list && \
- echo "deb-src http://mirror.sax.uk.as61049.net/mariadb/repo/10.3/ubuntu bionic main" >> \
+ echo "deb-src http://mirror.sax.uk.as61049.net/mariadb/repo/10.4/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/mariadb.list && \
  echo "**** install runtime packages ****" && \
  if [ -z ${MARIADB_VERSION+x} ]; then \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG MARIADB_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="thelamer"
 
 # environment variables
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -20,9 +20,9 @@ RUN \
  echo "add mariadb repository ****" && \
  echo "(redundant on armhf platform, but added for consistent dockerfile on all platforms) ****" && \
  apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8 && \
- echo "deb http://mirror.sax.uk.as61049.net/mariadb/repo/10.3/ubuntu bionic main" >> \
+ echo "deb http://mirror.sax.uk.as61049.net/mariadb/repo/10.4/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/mariadb.list && \
- echo "deb-src http://mirror.sax.uk.as61049.net/mariadb/repo/10.3/ubuntu bionic main" >> \
+ echo "deb-src http://mirror.sax.uk.as61049.net/mariadb/repo/10.4/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/mariadb.list && \
  echo "**** install runtime packages ****" && \
  if [ -z ${MARIADB_VERSION+x} ]; then \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG MARIADB_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs"
+LABEL maintainer="thelamer"
 
 # environment variables
 ARG DEBIAN_FRONTEND="noninteractive"
@@ -20,9 +20,9 @@ RUN \
  echo "add mariadb repository ****" && \
  echo "(redundant on armhf platform, but added for consistent dockerfile on all platforms) ****" && \
  apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8 && \
- echo "deb http://mirror.sax.uk.as61049.net/mariadb/repo/10.3/ubuntu bionic main" >> \
+ echo "deb http://mirror.sax.uk.as61049.net/mariadb/repo/10.4/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/mariadb.list && \
- echo "deb-src http://mirror.sax.uk.as61049.net/mariadb/repo/10.3/ubuntu bionic main" >> \
+ echo "deb-src http://mirror.sax.uk.as61049.net/mariadb/repo/10.4/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/mariadb.list && \
  echo "**** install runtime packages ****" && \
  apt-get update && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' curl -sX GET http://mirror.sax.uk.as61049.net/mariadb/repo/10.3/ubuntu/dists/bionic/main/binary-amd64/Packages |grep -A 7 -m 1 'Package: mariadb-server' | awk -F ': ' '/Version/{print $2;exit}' ''',
+            script: ''' curl -sX GET http://mirror.sax.uk.as61049.net/mariadb/repo/10.4/ubuntu/dists/bionic/main/binary-amd64/Packages |grep -A 7 -m 1 'Package: mariadb-server' | awk -F ': ' '/Version/{print $2;exit}' ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ docker create \
   -e MYSQL_DATABASE=<USER DB NAME> `#optional` \
   -e MYSQL_USER=<MYSQL USER> `#optional` \
   -e MYSQL_PASSWORD=<DATABASE PASSWORD> `#optional` \
+  -e MYSQL_ROOT_PASSWORD_FILE=/location/of/file `#optional` \
+  -e REMOTE_SQL=http://URL1/your.sql,https://URL2/your.sql `#optional` \
   -p 3306:3306 \
   -v <path to data>:/config \
   --restart unless-stopped \
@@ -93,6 +95,8 @@ services:
       - MYSQL_DATABASE=<USER DB NAME> #optional
       - MYSQL_USER=<MYSQL USER> #optional
       - MYSQL_PASSWORD=<DATABASE PASSWORD> #optional
+      - MYSQL_ROOT_PASSWORD_FILE=/location/of/file #optional
+      - REMOTE_SQL=http://URL1/your.sql,https://URL2/your.sql #optional
     volumes:
       - <path to data>:/config
     ports:
@@ -114,6 +118,8 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e MYSQL_DATABASE=<USER DB NAME>` | Specify the name of a database to be created on image startup. |
 | `-e MYSQL_USER=<MYSQL USER>` | This user will have superuser access to the database specified by MYSQL_DATABASE. |
 | `-e MYSQL_PASSWORD=<DATABASE PASSWORD>` | Set this to the password you want to use for you MYSQL_USER (minimum 4 characters). |
+| `-e MYSQL_ROOT_PASSWORD_FILE=/location/of/file` | Set this to the location of a text file containing your password. |
+| `-e REMOTE_SQL=http://URL1/your.sql,https://URL2/your.sql` | Set this to ingest sql files from an http/https endpoint (comma seperated array). |
 | `-v /config` | Contains the db itself and all assorted settings. |
 
 ## User / Group Identifiers
@@ -137,7 +143,7 @@ If you didn't set a password during installation, (see logs for warning) use
 `mysqladmin -u root password <PASSWORD>`
 to set one at the docker prompt...
 
-NOTE changing the MYSQL_ROOT_PASSWORD variable after the container has set up the initial databases has no effect, use the mysqladmin tool to change your mariadb password.
+NOTE changing the MYSQL_ROOT_PASSWORD or MYSQL_ROOT_PASSWORD_FILE variable after the container has set up the initial databases has no effect, use the mysqladmin tool to change your mariadb password.
 
 NOTE if you want to use (MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD) **all three** of these variables need to be set you cannot pick and choose.
 
@@ -145,6 +151,15 @@ Unraid users, it is advisable to edit the template/webui after setup and remove 
 
 Find custom.cnf in /config for config changes (restart container for them to take effect)
 , the databases in /config/databases and the log in /config/log/myqsl
+
+### Bootstrapping a new instance
+
+We support a one time run of custom sql files on init. In order to use this place `*.sql` files in:
+
+```
+/config/initdb.d/
+```
+This will have the same effect as setting the `REMOTE_SQL` environment variable. The sql will only be run on the containers first boot and setup.
 
 
 
@@ -212,6 +227,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **27.10.19:** - Bump to 10.4, ability use custom sql on initial init ,defining root passwords via file.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **07.03.19:** - Add ability to setup a database and default user on first spinup.
 * **26.01.19:** - Add pipeline logic and multi arch.

--- a/README.md
+++ b/README.md
@@ -62,15 +62,14 @@ docker create \
   --name=mariadb \
   -e PUID=1000 \
   -e PGID=1000 \
-  -e MYSQL_ROOT_PASSWORD=<DATABASE PASSWORD> \
+  -e MYSQL_ROOT_PASSWORD=ROOT_ACCESS_PASSWORD \
   -e TZ=Europe/London \
-  -e MYSQL_DATABASE=<USER DB NAME> `#optional` \
-  -e MYSQL_USER=<MYSQL USER> `#optional` \
-  -e MYSQL_PASSWORD=<DATABASE PASSWORD> `#optional` \
-  -e MYSQL_ROOT_PASSWORD_FILE=/location/of/file `#optional` \
+  -e MYSQL_DATABASE=USER_DB_NAME `#optional` \
+  -e MYSQL_USER=MYSQL_USER `#optional` \
+  -e MYSQL_PASSWORD=DATABASE_PASSWORD `#optional` \
   -e REMOTE_SQL=http://URL1/your.sql,https://URL2/your.sql `#optional` \
   -p 3306:3306 \
-  -v <path to data>:/config \
+  -v path_to_data:/config \
   --restart unless-stopped \
   linuxserver/mariadb
 ```
@@ -90,15 +89,14 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
-      - MYSQL_ROOT_PASSWORD=<DATABASE PASSWORD>
+      - MYSQL_ROOT_PASSWORD=ROOT_ACCESS_PASSWORD
       - TZ=Europe/London
-      - MYSQL_DATABASE=<USER DB NAME> #optional
-      - MYSQL_USER=<MYSQL USER> #optional
-      - MYSQL_PASSWORD=<DATABASE PASSWORD> #optional
-      - MYSQL_ROOT_PASSWORD_FILE=/location/of/file #optional
+      - MYSQL_DATABASE=USER_DB_NAME #optional
+      - MYSQL_USER=MYSQL_USER #optional
+      - MYSQL_PASSWORD=DATABASE_PASSWORD #optional
       - REMOTE_SQL=http://URL1/your.sql,https://URL2/your.sql #optional
     volumes:
-      - <path to data>:/config
+      - path_to_data:/config
     ports:
       - 3306:3306
     restart: unless-stopped
@@ -113,12 +111,11 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-p 3306` | Mariadb listens on this port. |
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
-| `-e MYSQL_ROOT_PASSWORD=<DATABASE PASSWORD>` | Set this to root password for installation (minimum 4 characters). |
+| `-e MYSQL_ROOT_PASSWORD=ROOT_ACCESS_PASSWORD` | Set this to root password for installation (minimum 4 characters). |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
-| `-e MYSQL_DATABASE=<USER DB NAME>` | Specify the name of a database to be created on image startup. |
-| `-e MYSQL_USER=<MYSQL USER>` | This user will have superuser access to the database specified by MYSQL_DATABASE. |
-| `-e MYSQL_PASSWORD=<DATABASE PASSWORD>` | Set this to the password you want to use for you MYSQL_USER (minimum 4 characters). |
-| `-e MYSQL_ROOT_PASSWORD_FILE=/location/of/file` | Set this to the location of a text file containing your password. |
+| `-e MYSQL_DATABASE=USER_DB_NAME` | Specify the name of a database to be created on image startup. |
+| `-e MYSQL_USER=MYSQL_USER` | This user will have superuser access to the database specified by MYSQL_DATABASE (do not use root here). |
+| `-e MYSQL_PASSWORD=DATABASE_PASSWORD` | Set this to the password you want to use for you MYSQL_USER (minimum 4 characters). |
 | `-e REMOTE_SQL=http://URL1/your.sql,https://URL2/your.sql` | Set this to ingest sql files from an http/https endpoint (comma seperated array). |
 | `-v /config` | Contains the db itself and all assorted settings. |
 
@@ -143,7 +140,7 @@ If you didn't set a password during installation, (see logs for warning) use
 `mysqladmin -u root password <PASSWORD>`
 to set one at the docker prompt...
 
-NOTE changing the MYSQL_ROOT_PASSWORD or MYSQL_ROOT_PASSWORD_FILE variable after the container has set up the initial databases has no effect, use the mysqladmin tool to change your mariadb password.
+NOTE changing the MYSQL_ROOT_PASSWORD variable after the container has set up the initial databases has no effect, use the mysqladmin tool to change your mariadb password.
 
 NOTE if you want to use (MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD) **all three** of these variables need to be set you cannot pick and choose.
 
@@ -151,6 +148,26 @@ Unraid users, it is advisable to edit the template/webui after setup and remove 
 
 Find custom.cnf in /config for config changes (restart container for them to take effect)
 , the databases in /config/databases and the log in /config/log/myqsl
+
+### Loading passwords and users from files
+
+The `MYSQL_ROOT_PASSWORD MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD REMOTE_SQL` env values can be set in a file: 
+
+```
+/config/env
+```
+
+Using the following format: 
+
+```
+MYSQL_ROOT_PASSWORD="ROOT_ACCESS_PASSWORD"
+MYSQL_DATABASE="USER_DB_NAME"
+MYSQL_USER="MYSQL_USER"
+MYSQL_PASSWORD="DATABASE_PASSWORD"
+REMOTE_SQL="http://URL1/your.sql,https://URL2/your.sql"
+```
+
+These settings can be mixed and matched with Docker ENV settings as you require, but the settings in the file will always take precedence.
 
 ### Bootstrapping a new instance
 

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-mariadb
 external_type: na
-custom_version_command: "curl -sX GET http://mirror.sax.uk.as61049.net/mariadb/repo/10.3/ubuntu/dists/bionic/main/binary-amd64/Packages |grep -A 7 -m 1 'Package: mariadb-server' | awk -F ': ' '/Version/{print $2;exit}'"
+custom_version_command: "curl -sX GET http://mirror.sax.uk.as61049.net/mariadb/repo/10.4/ubuntu/dists/bionic/main/binary-amd64/Packages |grep -A 7 -m 1 'Package: mariadb-server' | awk -F ': ' '/Version/{print $2;exit}'"
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -23,11 +23,11 @@ param_container_name: "{{ project_name }}"
 param_usage_include_net: false
 param_usage_include_env: true
 param_env_vars:
-  - { env_var: "MYSQL_ROOT_PASSWORD", env_value: "<DATABASE PASSWORD>", desc: "Set this to root password for installation (minimum 4 characters)." }
+  - { env_var: "MYSQL_ROOT_PASSWORD", env_value: "ROOT_ACCESS_PASSWORD", desc: "Set this to root password for installation (minimum 4 characters)." }
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London." }
 param_usage_include_vols: true
 param_volumes:
-  - { vol_path: "/config", vol_host_path: "<path to data>", desc: "Contains the db itself and all assorted settings." }
+  - { vol_path: "/config", vol_host_path: "path_to_data", desc: "Contains the db itself and all assorted settings." }
 param_usage_include_ports: true
 param_ports:
   - { external_port: "3306", internal_port: "3306", port_desc: "Mariadb listens on this port." }
@@ -37,10 +37,9 @@ cap_add_param: false
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "MYSQL_DATABASE", env_value: "<USER DB NAME>", desc: "Specify the name of a database to be created on image startup." }
-  - { env_var: "MYSQL_USER", env_value: "<MYSQL USER>", desc: "This user will have superuser access to the database specified by MYSQL_DATABASE." }
-  - { env_var: "MYSQL_PASSWORD", env_value: "<DATABASE PASSWORD>", desc: "Set this to the password you want to use for you MYSQL_USER (minimum 4 characters)." }
-  - { env_var: "MYSQL_ROOT_PASSWORD_FILE", env_value: "/location/of/file", desc: "Set this to the location of a text file containing your password." }
+  - { env_var: "MYSQL_DATABASE", env_value: "USER_DB_NAME", desc: "Specify the name of a database to be created on image startup." }
+  - { env_var: "MYSQL_USER", env_value: "MYSQL_USER", desc: "This user will have superuser access to the database specified by MYSQL_DATABASE (do not use root here)." }
+  - { env_var: "MYSQL_PASSWORD", env_value: "DATABASE_PASSWORD", desc: "Set this to the password you want to use for you MYSQL_USER (minimum 4 characters)." }
   - { env_var: "REMOTE_SQL", env_value: "http://URL1/your.sql,https://URL2/your.sql", desc: "Set this to ingest sql files from an http/https endpoint (comma seperated array)." }
 opt_param_usage_include_vols: false
 opt_param_usage_include_ports: false
@@ -55,7 +54,7 @@ app_setup_block: |
   `mysqladmin -u root password <PASSWORD>`
   to set one at the docker prompt...
 
-  NOTE changing the MYSQL_ROOT_PASSWORD or MYSQL_ROOT_PASSWORD_FILE variable after the container has set up the initial databases has no effect, use the mysqladmin tool to change your mariadb password.
+  NOTE changing the MYSQL_ROOT_PASSWORD variable after the container has set up the initial databases has no effect, use the mysqladmin tool to change your mariadb password.
 
   NOTE if you want to use (MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD) **all three** of these variables need to be set you cannot pick and choose.
 
@@ -63,6 +62,26 @@ app_setup_block: |
 
   Find custom.cnf in /config for config changes (restart container for them to take effect)
   , the databases in /config/databases and the log in /config/log/myqsl
+
+  ### Loading passwords and users from files
+  
+  The `MYSQL_ROOT_PASSWORD MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD REMOTE_SQL` env values can be set in a file: 
+  
+  ```
+  /config/env
+  ```
+  
+  Using the following format: 
+  
+  ```
+  MYSQL_ROOT_PASSWORD="ROOT_ACCESS_PASSWORD"
+  MYSQL_DATABASE="USER_DB_NAME"
+  MYSQL_USER="MYSQL_USER"
+  MYSQL_PASSWORD="DATABASE_PASSWORD"
+  REMOTE_SQL="http://URL1/your.sql,https://URL2/your.sql"
+  ```
+  
+  These settings can be mixed and matched with Docker ENV settings as you require, but the settings in the file will always take precedence.
 
   ### Bootstrapping a new instance
   

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -40,6 +40,8 @@ opt_param_env_vars:
   - { env_var: "MYSQL_DATABASE", env_value: "<USER DB NAME>", desc: "Specify the name of a database to be created on image startup." }
   - { env_var: "MYSQL_USER", env_value: "<MYSQL USER>", desc: "This user will have superuser access to the database specified by MYSQL_DATABASE." }
   - { env_var: "MYSQL_PASSWORD", env_value: "<DATABASE PASSWORD>", desc: "Set this to the password you want to use for you MYSQL_USER (minimum 4 characters)." }
+  - { env_var: "MYSQL_ROOT_PASSWORD_FILE", env_value: "/location/of/file", desc: "Set this to the location of a text file containing your password." }
+  - { env_var: "REMOTE_SQL", env_value: "http://URL1/your.sql,https://URL2/your.sql", desc: "Set this to ingest sql files from an http/https endpoint (comma seperated array)." }
 opt_param_usage_include_vols: false
 opt_param_usage_include_ports: false
 opt_param_device_map: false
@@ -53,7 +55,7 @@ app_setup_block: |
   `mysqladmin -u root password <PASSWORD>`
   to set one at the docker prompt...
 
-  NOTE changing the MYSQL_ROOT_PASSWORD variable after the container has set up the initial databases has no effect, use the mysqladmin tool to change your mariadb password.
+  NOTE changing the MYSQL_ROOT_PASSWORD or MYSQL_ROOT_PASSWORD_FILE variable after the container has set up the initial databases has no effect, use the mysqladmin tool to change your mariadb password.
 
   NOTE if you want to use (MYSQL_DATABASE MYSQL_USER MYSQL_PASSWORD) **all three** of these variables need to be set you cannot pick and choose.
 
@@ -62,8 +64,18 @@ app_setup_block: |
   Find custom.cnf in /config for config changes (restart container for them to take effect)
   , the databases in /config/databases and the log in /config/log/myqsl
 
+  ### Bootstrapping a new instance
+  
+  We support a one time run of custom sql files on init. In order to use this place `*.sql` files in:
+  
+  ```
+  /config/initdb.d/
+  ```
+  This will have the same effect as setting the `REMOTE_SQL` environment variable. The sql will only be run on the containers first boot and setup.
+
 # changelog
 changelogs:
+  - { date: "27.10.19:", desc: "Bump to 10.4, ability use custom sql on initial init ,defining root passwords via file." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "07.03.19:", desc: "Add ability to setup a database and default user on first spinup." }
   - { date: "26.01.19:", desc: "Add pipeline logic and multi arch." }

--- a/root/etc/cont-init.d/40-initialise-db
+++ b/root/etc/cont-init.d/40-initialise-db
@@ -84,7 +84,6 @@ if [ -n "${REMOTE_SQL+set}" ]; then
     fi
   done
 fi
-cat "$tempSqlFile"
 # set some permissions needed before we begin initialising
 chown -R abc:abc /config/log/mysql /var/run/mysqld
 chmod -R 777 /config/log/mysql /var/run/mysqld

--- a/root/etc/cont-init.d/40-initialise-db
+++ b/root/etc/cont-init.d/40-initialise-db
@@ -34,21 +34,26 @@ EOFPASS
 
 # test for empty password variable, if it's set to 0 or less than 4 characters
 if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
-TEST_LEN="0"
+  if [ -f "$MYSQL_ROOT_PASSWORD_FILE" ]; then
+    MYSQL_ROOT_PASSWORD=$(< "$MYSQL_ROOT_PASSWORD_FILE")
+    TEST_LEN=${#MYSQL_ROOT_PASSWORD}
+  else
+    TEST_LEN="0"
+  fi
 else
-TEST_LEN=${#MYSQL_ROOT_PASSWORD}
+  TEST_LEN=${#MYSQL_ROOT_PASSWORD}
 fi
 if [ "$TEST_LEN" -lt "4" ]; then
-MYSQL_PASS="CREATE USER 'root'@'%' IDENTIFIED BY '' ;"
+  MYSQL_PASS="CREATE USER 'root'@'%' IDENTIFIED BY '' ;"
 else
-MYSQL_PASS="CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;"
+  MYSQL_PASS="CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;"
 fi
 
 # Make sure all user and database settings are set and pass is more than 4 characters
 if [ "${MYSQL_USER+x}" ] && \
 [ "${MYSQL_DATABASE+x}" ] && \
 [ "${MYSQL_PASSWORD+x}" ] && \
-[ "${#MYSQL_PASSWORD}" -gt "4" ]; then
+[ "${#MYSQL_PASSWORD}" -gt "3" ]; then
 read -r -d '' MYSQL_DB_SETUP << EOM
 CREATE DATABASE \`${MYSQL_DATABASE}\`;
 CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
@@ -65,6 +70,21 @@ $MYSQL_DB_SETUP
 EONEWSQL
 echo "Setting Up Initial Databases"
 
+# add all sql from a user defined directory on first init
+if ([ -e "/config/initdb.d" ] && [ -n "$(/bin/ls -A /config/initdb.d/*.sql 2>/dev/null)" ]); then
+  cat /config/initdb.d/*.sql >> "$tempSqlFile"
+fi
+
+# ingest remote sql if REMOTE_SQL is set
+if [ -n "${REMOTE_SQL+set}" ]; then
+  IFS=, read -ra URLS <<< "${REMOTE_SQL}"
+  for URL in "${URLS[@]}"; do
+    if [ $(curl -I -sL -w "%{http_code}" "${URL}" -o /dev/null) == 200 ]; then
+      curl -sL "${URL}" >> "$tempSqlFile"
+    fi
+  done
+fi
+cat "$tempSqlFile"
 # set some permissions needed before we begin initialising
 chown -R abc:abc /config/log/mysql /var/run/mysqld
 chmod -R 777 /config/log/mysql /var/run/mysqld
@@ -82,8 +102,8 @@ echo "Database Setup Completed"
 
 # display a message about password if not set or too short
 if [ "$TEST_LEN" -lt "4" ]; then
-printf '\n\n\n%s\n\n\n' "$(</tmp/no-pass.nfo)"
-sleep 5s
+  printf '\n\n\n%s\n\n\n' "$(</tmp/no-pass.nfo)"
+  sleep 5s
 fi
 
 # do some more owning to finish our first run sequence
@@ -96,11 +116,11 @@ chown -R abc:abc /var/run/mysqld
 
 # clean up any old install files from /tmp
 if [ -f "/tmp/no-pass.nfo" ]; then
-rm /tmp/no-pass.nfo
+  rm /tmp/no-pass.nfo
 fi
 
 if [ -f "/tmp/mysql-first-time.sql" ]; then
-rm /tmp/mysql-first-time.sql
+  rm /tmp/mysql-first-time.sql
 fi
 
 chown -R abc:abc /config

--- a/root/etc/cont-init.d/40-initialise-db
+++ b/root/etc/cont-init.d/40-initialise-db
@@ -15,6 +15,11 @@ done
 # test for existence of mysql file in datadir and start initialise if not present
 if [ ! -d "$DATADIR/mysql" ]; then
 
+# load env file if it exists
+if [ -f "/config/env" ]; then
+  source /config/env
+fi
+
 # set basic sql command
 tempSqlFile='/tmp/mysql-first-time.sql'
 cat > "$tempSqlFile" <<-EOSQL
@@ -34,12 +39,7 @@ EOFPASS
 
 # test for empty password variable, if it's set to 0 or less than 4 characters
 if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
-  if [ -f "$MYSQL_ROOT_PASSWORD_FILE" ]; then
-    MYSQL_ROOT_PASSWORD=$(< "$MYSQL_ROOT_PASSWORD_FILE")
-    TEST_LEN=${#MYSQL_ROOT_PASSWORD}
-  else
-    TEST_LEN="0"
-  fi
+  TEST_LEN="0"
 else
   TEST_LEN=${#MYSQL_ROOT_PASSWORD}
 fi


### PR DESCRIPTION
Tested pretty heavily locally. 

The only difference between this and official image is we will not execute bash scripts on init.

The bump to 10.4 really is the only toss up here as we have had a reported issue on I tested a direct upgrade from the previous image dataset with a test db all good for me. 

If this is merged the trigger endpoint needs to be changed here: 
https://ci.linuxserver.io/job/External-Triggers/job/mariadb-external-trigger/