### PR TITLE
Add USE clause before including init and remote SQL scripts to run them in the default database.

### DIFF
--- a/root/etc/cont-init.d/40-initialise-db
+++ b/root/etc/cont-init.d/40-initialise-db
@@ -50,6 +50,7 @@ else
 fi
 
 # Make sure all user and database settings are set and pass is more than 4 characters
+# At the end change to default database created with environment variables to run init and remote scripts there
 if [ "${MYSQL_USER+x}" ] && \
 [ "${MYSQL_DATABASE+x}" ] && \
 [ "${MYSQL_PASSWORD+x}" ] && \
@@ -58,6 +59,7 @@ read -r -d '' MYSQL_DB_SETUP << EOM
 CREATE DATABASE \`${MYSQL_DATABASE}\`;
 CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
 GRANT ALL PRIVILEGES ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%';
+USE \`${MYSQL_DATABASE}\`;
 EOM
 fi
 
@@ -69,8 +71,6 @@ DROP DATABASE IF EXISTS test ;
 $MYSQL_DB_SETUP
 EONEWSQL
 echo "Setting Up Initial Databases"
-
-echo "USE ${MYSQL_DATABASE};" >> "$tempSqlFile"
 
 # add all sql from a user defined directory on first init
 if ([ -e "/config/initdb.d" ] && [ -n "$(/bin/ls -A /config/initdb.d/*.sql 2>/dev/null)" ]); then

--- a/root/etc/cont-init.d/40-initialise-db
+++ b/root/etc/cont-init.d/40-initialise-db
@@ -70,6 +70,8 @@ $MYSQL_DB_SETUP
 EONEWSQL
 echo "Setting Up Initial Databases"
 
+echo "USE ${MYSQL_DATABASE};" >> "$tempSqlFile"
+
 # add all sql from a user defined directory on first init
 if ([ -e "/config/initdb.d" ] && [ -n "$(/bin/ls -A /config/initdb.d/*.sql 2>/dev/null)" ]); then
   cat /config/initdb.d/*.sql >> "$tempSqlFile"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
Add a `USE` statement to `/tmp/mysql-first-time.sql` before running user init and remote bootstrapping SQL scripts to run them in the default database (code change in `/etc/cont-init.d/40-initialise-db`).

## Benefits of this PR and context:
This makes the bootstrapping the default database consistent with the official mariadb image and enables users to not have to change their base SQL scripts while selecting a DB name with environment variable while creating the container. This improves felixibility and mobility of containers, and makes it simpler to init simple single-database systems with some initial DB structure.

## How Has This Been Tested?
I built the Docker container and started it with the same `docker-compose.yml` as stated in my issue #48. I then opened a shell into the container and checked with the mysql command that the contents of my init script (located in `/etc/cont.init.d/`) had been imported to the default database that was created by supplying environment variables to the container.


## Source / References:
Issue #48.
