### PR TITLE
Update my.cnf

### DIFF
--- a/root/defaults/my.cnf
+++ b/root/defaults/my.cnf
@@ -4,6 +4,7 @@
 nice		= 0
 
 [mysqld]
+character-set-server	= utf8
 max_connections		= 100
 connect_timeout		= 5
 wait_timeout		= 600
@@ -137,6 +138,3 @@ max_allowed_packet	= 16M
 
 [isamchk]
 key_buffer_size		= 16M
-
-
-


### PR DESCRIPTION
Ref: https://discourse.linuxserver.io/t/request-change-defaults-from-latin1-latin1-swedish-ci-to-utf8/668

> The **mariadb** container defaults to `latin1` character set and `latin1_swedish_ci` (!) collation. You can verify this by running:
> 
>     root@mariadb:/# mysqladmin -u root -p var | grep -E 'character|collation' | tr -s ' '
>     Enter password:
>     | character_set_client | latin1 |                    ◀︎——
>     | character_set_connection | latin1 |                ◀︎——
>     | character_set_database | latin1 |                  ◀︎——
>     | character_set_filesystem | binary |
>     | character_set_results | latin1 |                   ◀︎——
>     | character_set_server | latin1 |                    ◀︎——
>     | character_set_system | utf8 |                      ◀︎—— internal tables are UTF8 by default
>     | character_sets_dir | /usr/share/mysql/charsets/ |
>     | collation_connection | latin1_swedish_ci |         ◀︎——
>     | collation_database | latin1_swedish_ci |           ◀︎——
>     | collation_server | latin1_swedish_ci |             ◀︎——
> 
> The fix for this is to add add  **character-set-server=utf8** in the **[mysqld]** section of **/etc/mysql/my.cnf**:
> 
>     [mysqld]
>         character-set-server=utf8
> 
> After this change:
> 
>     | character_set_client | utf8 |
>     | character_set_connection | utf8 |
>     | character_set_database | utf8 |
>     | character_set_filesystem | binary |
>     | character_set_results | utf8 |
>     | character_set_server | utf8 |
>     | character_set_system | utf8 |
>     | character_sets_dir | /usr/share/mysql/charsets/ |
>     | collation_connection | utf8_general_ci |
>     | collation_database | utf8_general_ci |
>     | collation_server | utf8_general_ci |
> 
> Note, only databases and tables created **after** this change will be created with utf8 character sets and collations. Any databases before this change, will still be `latin1` and `latin1_swedish_ci`.
> 
> **I'd like to see the default LinuxServer MariaDB container updated with the above modification so the default sorting/collation is UTF-8.** If this isn't the appropriate place for this request, let me know.