### PR TITLE
Fix issue with apostrophe in passwords

### DIFF
--- a/root/etc/cont-init.d/40-initialise-db
+++ b/root/etc/cont-init.d/40-initialise-db
@@ -43,6 +43,7 @@ if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
 else
   TEST_LEN=${#MYSQL_ROOT_PASSWORD}
 fi
+MYSQL_ROOT_PASSWORD=$(sed -E 's/('\'')/\\\1/g' <<< $MYSQL_ROOT_PASSWORD)
 if [ "$TEST_LEN" -lt "4" ]; then
   MYSQL_PASS="CREATE USER 'root'@'%' IDENTIFIED BY '' ;"
 else
@@ -55,6 +56,7 @@ if [ "${MYSQL_USER+x}" ] && \
 [ "${MYSQL_DATABASE+x}" ] && \
 [ "${MYSQL_PASSWORD+x}" ] && \
 [ "${#MYSQL_PASSWORD}" -gt "3" ]; then
+MYSQL_PASSWORD=$(sed -E 's/('\'')/\\\1/g' <<< $MYSQL_PASSWORD)
 read -r -d '' MYSQL_DB_SETUP << EOM
 CREATE DATABASE \`${MYSQL_DATABASE}\`;
 CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';


### PR DESCRIPTION
closes #63 
should support easy modification if we discover other problematic characters.
tested on my machine with single and multiple `'` in passwords