### PR TITLE
Use edge instead of main

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -18,7 +18,7 @@ jobs:
           fi
           echo "**** External trigger running off of alpine branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_MARIADB_ALPINE\". ****"
           echo "**** Retrieving external version ****"
-          EXT_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
+          EXT_RELEASE=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
             && awk '/^P:'"mariadb"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://')
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "**** Can't retrieve external version, exiting ****"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,10 @@ RUN \
 	curl && \
  echo "**** install runtime packages ****" && \
  if [ -z ${MARIADB_VERSION+x} ]; then \
-	MARIADB_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
+	MARIADB_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
 	&& awk '/^P:mariadb$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
  fi && \
- apk add --no-cache \
+ apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ \
 	gnupg \
 	mariadb==${MARIADB_VERSION} \
 	mariadb-backup==${MARIADB_VERSION} \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,10 +17,10 @@ RUN \
 	curl && \
  echo "**** install runtime packages ****" && \
  if [ -z ${MARIADB_VERSION+x} ]; then \
-	MARIADB_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
+	MARIADB_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
 	&& awk '/^P:mariadb$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
  fi && \
- apk add --no-cache \
+ apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ \
 	gnupg \
 	mariadb==${MARIADB_VERSION} \
 	mariadb-backup==${MARIADB_VERSION} \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -17,10 +17,10 @@ RUN \
 	curl && \
  echo "**** install runtime packages ****" && \
  if [ -z ${MARIADB_VERSION+x} ]; then \
-	MARIADB_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
+	MARIADB_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
 	&& awk '/^P:mariadb$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
  fi && \
- apk add --no-cache \
+ apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ \
 	gnupg \
 	mariadb==${MARIADB_VERSION} \
 	mariadb-backup==${MARIADB_VERSION} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     PR_DOCKERHUB_IMAGE = 'lspipepr/mariadb'
     DIST_IMAGE = 'alpine'
     DIST_TAG = '3.13'
-    DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/v3.13/main/'
+    DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/edge/main/'
     DIST_REPO_PACKAGES = 'mariadb'
     MULTIARCH='true'
     CI='true'

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -16,7 +16,7 @@ repo_vars:
   - PR_DOCKERHUB_IMAGE = 'lspipepr/mariadb'
   - DIST_IMAGE = 'alpine'
   - DIST_TAG = '3.13'
-  - DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/v3.13/main/'
+  - DIST_REPO = 'http://dl-cdn.alpinelinux.org/alpine/edge/main/'
   - DIST_REPO_PACKAGES = 'mariadb'
   - MULTIARCH='true'
   - CI='true'


### PR DESCRIPTION
This is a temporary commit that should solve https://github.com/linuxserver/docker-mariadb/issues/76 and supersede https://github.com/linuxserver/docker-mariadb/pull/80
Noted in the upstream issues, edge contains newer packages that resolve the issue
This entire commit can be reverted once main has mariadb 10.5.9 and possibly musl 1.2.2-r2

NEEDS TESTING!

We need to have people with armhf test `lspipepr/mariadb:arm32v7-alpine-10.5.9-r0-pkg-6271d700-pr-81` on actual hardware to confirm the fix.