### PR TITLE
Fix permission error on initdb.d scripts

### DIFF
--- a/root/etc/cont-init.d/40-initialise-db
+++ b/root/etc/cont-init.d/40-initialise-db
@@ -73,13 +73,16 @@ GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
 DROP DATABASE IF EXISTS test ;
 $MYSQL_DB_SETUP
 EONEWSQL
-chown -R abc:abc "${tempSqlFile}"
+
 echo "Setting Up Initial Databases"
 
 # add all sql from a user defined directory on first init
 if [ -e "/config/initdb.d" ] && [ -n "$(/bin/ls -A /config/initdb.d/*.sql 2>/dev/null)" ]; then
   cat /config/initdb.d/*.sql >> "${tempSqlFile}"
 fi
+
+chown -R abc:abc "${tempSqlFile}"
+
 
 # ingest remote sql if REMOTE_SQL is set
 if [ -n "${REMOTE_SQL+set}" ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-mariadb/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This PR fixes a permission error when `initdb.d` scripts are added to the default SQL init script. This PR closes #87 

## Benefits of this PR and context:
This PR will reconcile the behaviour of the alpine version with the ubuntu one.

## How Has This Been Tested?
A SQL script to create a new database was added to the `/config/initdb.d/` folder and it was checked that the database was created.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
