### PR TITLE
remove curl install/purge from Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,6 @@ ENV MYSQL_DIR="/config"
 ENV DATADIR=$MYSQL_DIR/databases
 
 RUN \
-  echo "**** install build packages ****" && \
-  apk add --no-cache --virtual=build-dependencies \
-    curl && \
   echo "**** install runtime packages ****" && \
   if [ -z ${MARIADB_VERSION+x} ]; then \
     MARIADB_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
@@ -28,8 +25,6 @@ RUN \
     mariadb-common==${MARIADB_VERSION} \
     mariadb-server-utils==${MARIADB_VERSION} && \
   echo "**** cleanup ****" && \
-  apk del --purge \
-    build-dependencies && \
   rm -rf \
       /root/.cache \
       /tmp/* && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -12,9 +12,6 @@ ENV MYSQL_DIR="/config"
 ENV DATADIR=$MYSQL_DIR/databases
 
 RUN \
-  echo "**** install build packages ****" && \
-  apk add --no-cache --virtual=build-dependencies \
-    curl && \
   echo "**** install runtime packages ****" && \
   if [ -z ${MARIADB_VERSION+x} ]; then \
     MARIADB_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
@@ -28,8 +25,6 @@ RUN \
     mariadb-common==${MARIADB_VERSION} \
     mariadb-server-utils==${MARIADB_VERSION} && \
   echo "**** cleanup ****" && \
-  apk del --purge \
-    build-dependencies && \
   rm -rf \
       /root/.cache \
       /tmp/* && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -12,9 +12,6 @@ ENV MYSQL_DIR="/config"
 ENV DATADIR=$MYSQL_DIR/databases
 
 RUN \
-  echo "**** install build packages ****" && \
-  apk add --no-cache --virtual=build-dependencies \
-    curl && \
   echo "**** install runtime packages ****" && \
   if [ -z ${MARIADB_VERSION+x} ]; then \
     MARIADB_VERSION=$(curl -sL "http://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz" | tar -xz -C /tmp \
@@ -28,8 +25,6 @@ RUN \
     mariadb-common==${MARIADB_VERSION} \
     mariadb-server-utils==${MARIADB_VERSION} && \
   echo "**** cleanup ****" && \
-  apk del --purge \
-    build-dependencies && \
   rm -rf \
       /root/.cache \
       /tmp/* && \


### PR DESCRIPTION
We already install curl in baseimage-alpine. we were then installing into the container itself as a build-dependency and then purging it. Had this actually been working, it would've broken our remote-sql function in 40-initialise-db, but fortunately it appear the purge did not actually remove curl.  This just removed the superfluous lines from the dockerfiles with no functional change. 