### PR TITLE
Update run

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-mariadb-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-mariadb-config/run
@@ -15,6 +15,9 @@ cp -n /defaults/custom.cnf /config/custom.cnf
 rm -rf /etc/my.cnf.d/custom.cnf
 ln -s /config/custom.cnf /etc/my.cnf.d/custom.cnf
 
+# remove orphan pid file
+[ -f /var/run/mysqld/mysqld.pid ] && rm /var/run/mysqld/mysqld.pid
+
 # set permissions
 chmod -R 777 \
     /var/run/mysqld


### PR DESCRIPTION
fix for Orphan pid file
## Description:

updates run file to remove orphan pid file when container is restarted

## Benefits of this PR and context:
Fix for issue

https://github.com/linuxserver/docker-mariadb/issues/155

## How Has This Been Tested?

Container can now reboot wihttps://github.com/linuxserver/docker-mariadb/issues/155hout issues 


